### PR TITLE
add curl timeout options to reduce attack surface

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,8 @@ Madmatt\ElasticProxy\ElasticsearchController:
       - curations
       - schema
       - synonyms
+  curl_connect_timeout: 2
+  curl_timeout: 5
 SilverStripe\Control\Director:
   rules:
     # We need this to include 6 params because the default Silverstripe rule only includes 3, and the Elastic-generated URL looks like /api/as/v1/engines/<engine name>/search.json
@@ -69,7 +71,10 @@ SilverStripe\Control\Director:
 ```
 
 Here you can also define the list of endpoints allowed to be accessed through the proxy, for example if you are only using it
-for autocomplete, you can allow only `query_suggestion`
+for autocomplete, you can allow only `query_suggestion`.
+
+Additional options exist for changing the curl options `CURLOPT_CONNECTTIMEOUT` and `CURLOPT_TIMEOUT`. **Caution**:
+increasing these values increases the attack surface area for someone attacking the site, so proceed carefully.
 
 By default, this controller will run all created `HTTPMiddleware` layers, however you may need to configure these (for example, specific rate limiting for this endpoint).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,8 +73,13 @@ SilverStripe\Control\Director:
 Here you can also define the list of endpoints allowed to be accessed through the proxy, for example if you are only using it
 for autocomplete, you can allow only `query_suggestion`.
 
-Additional options exist for changing the curl options `CURLOPT_CONNECTTIMEOUT` and `CURLOPT_TIMEOUT`. **Caution**:
-increasing these values increases the attack surface area for someone attacking the site, so proceed carefully.
+Additional options exist for changing the curl options `CURLOPT_CONNECTTIMEOUT`
+and `CURLOPT_TIMEOUT` when passing the request to Elastic.
+
+**Caution:
+These are intentionally set lower than the default of 30 seconds to lower the impact of denial of
+service attacks when Elastic is unavailable or under heavy load. Raising these
+limits is possible, but you should only do so if regular queries are timing out.**
 
 By default, this controller will run all created `HTTPMiddleware` layers, however you may need to configure these (for example, specific rate limiting for this endpoint).
 

--- a/search-proxy.php
+++ b/search-proxy.php
@@ -115,5 +115,9 @@ curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 curl_setopt($curl, CURLOPT_POST, true);
 curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
 
+// Set a reasonable timeout to lower attack surface (in seconds)
+curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 2);
+curl_setopt($curl, CURLOPT_TIMEOUT, 5);
+
 // This will return the results of the API query out to stdout for the frontend library to interpret
 curl_exec($curl);

--- a/src/ElasticsearchController.php
+++ b/src/ElasticsearchController.php
@@ -34,6 +34,18 @@ class ElasticsearchController extends Controller
 
     /**
      * @config
+     * @var int time in seconds allowed for curl to make a successful connection
+     */
+    private static $curl_connect_timeout = 2;
+
+    /**
+     * @config
+     * @var int time in seconds allowed for curl to make a return a successful response
+     */
+    private static $curl_timeout = 5;
+
+    /**
+     * @config
      * @var string[]
      * A list of endpoints that should be allowed to be hit via this proxy
      */
@@ -131,6 +143,10 @@ class ElasticsearchController extends Controller
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_POST, true);
         curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
+
+        // Set a reasonable timeout to lower attack surface
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->config()->curl_connect_timeout);
+        curl_setopt($curl, CURLOPT_TIMEOUT, $this->config()->curl_timeout);
 
         // This will return the results of the API query out to stdout for the frontend library to interpret
         $response = curl_exec($curl);


### PR DESCRIPTION
Sets sensible defaults of 2 secs for connection, 5 seconds for response.

Configurable on controller-based implementation